### PR TITLE
added Db class and instatiated class in index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,9 +1,7 @@
 <?php
-require_once __DIR__. '/vendor/autoload.php';
+require_once __DIR__ . '/vendor/autoload.php';
 
 use \Mamoi\Resources\Db;
 
 $db = new Db();
 $connection = $db->getConnection();
-
-var_dump($connection); // for testing purposes only delete once done

--- a/index.php
+++ b/index.php
@@ -1,0 +1,9 @@
+<?php
+require_once __DIR__. '/vendor/autoload.php';
+
+use \Mamoi\Resources\Db;
+
+$db = new Db();
+$connection = $db->getConnection();
+
+var_dump($connection); // for testing purposes only delete once done

--- a/src/Resources/Db.php
+++ b/src/Resources/Db.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Mamoi\Resources;
+
+class Db
+{
+    private $db;
+
+    public function __construct()
+    {
+        $this->db = new \PDO('mysql:host=db; dbname=ingredients', 'root', 'password');
+    }
+
+    /**  Getter for database connection
+     *
+     * @return \PDO instantiated object which contains database credentials
+     */
+    public function getConnection()
+    {
+        return $this->db;
+    }
+}
+


### PR DESCRIPTION
Testing details.

- Create new local DB in SQL pro called 'ingredients'.
- Import sql file 'ingredients.sql' which is saved in the db folder on the project.
- Included in the index.php file is a var_dump of the connection. Run the index.php and you should get back a PDO object for a successful test.
-Remember after testing to remove the var_dump ($connection)