### PR TITLE
S3 t2 recipe entity class

### DIFF
--- a/src/Entities/RecipeEntity.php
+++ b/src/Entities/RecipeEntity.php
@@ -1,6 +1,8 @@
 <?php
 
+
 namespace Mamoi\Entities;
+
 
 class RecipeEntity
 {

--- a/src/Entities/RecipeEntity.php
+++ b/src/Entities/RecipeEntity.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Mamoi\Entities;
+
+class RecipeEntity
+{
+    private $title;
+    private $href;
+    private $ingredients;
+    private $thumbnail;
+
+    public function __construct(string $title, string $href, string $ingredients, string $img)
+    {
+        $this->title = $title;
+        $this->href = $href;
+        $this->ingredients = $ingredients;
+        $this->thumbnail = $img;
+    }
+
+    /** Getter for recipe title
+     *
+     * @return string
+     */
+    public function getTitle() : string
+    {
+        return $this->title;
+    }
+
+    /** Getter for recipe link
+     *
+     * @return string
+     */
+    public function getHref() : string
+    {
+        return $this->href;
+    }
+
+    /** Getter for recipe ingredients
+     *
+     * @return string
+     */
+    public function getIngredients() : string
+    {
+        return $this->ingredients;
+    }
+
+    /** Getter for recipe img
+     *
+     * @return string
+     */
+    public function getThumbnail() : string {
+        return $this->thumbnail;
+    }
+}

--- a/test/src/Entities/RecipeEntityTest.php
+++ b/test/src/Entities/RecipeEntityTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+require_once  dirname(__FILE__, 4) . '/vendor/autoload.php';
+
+class RecipeEntityTest extends TestCase
+{
+
+    /**
+     *  Success test case for recipe entity constructor.
+     *  Must generate an instance of the recipe class entity when given correct data-types
+     */
+    public function testConstructorRecipeEntitySuccess()
+    {
+        $title = 'test-title';
+        $href = 'test-href';
+        $ingredients = 'test-ingredients';
+        $thumbnail = 'test-thumbnail';
+
+        $recipe = new \Mamoi\Entities\RecipeEntity($title, $href, $ingredients, $thumbnail);
+        $this->assertInstanceOf(\Mamoi\Entities\RecipeEntity::class, $recipe);
+    }
+
+    /**
+     *  Malformed test case
+     *  Expecting an exception when passed an unexpected data type as parameter
+     */
+    public function testConstructorRecipeEntityMalformed()
+    {
+        $title = [];
+        $href = 'test-href';
+        $ingredients = 'test-ingredients';
+        $thumbnail = 'test-thumbnail';
+
+        $this->expectException(TypeError::class);
+        $recipe = new \Mamoi\Entities\RecipeEntity($title, $href, $ingredients, $thumbnail);
+    }
+}


### PR DESCRIPTION
Created Recipe Entity Class and Matching Unit Test File.

Run phpunit RecipeEntityTest.php

class taking:
$title;
$href;
$ingredients;
$thumbnail; 

(NOTE: we said initially in planning this property would be called "img" but data received from api is "thumbnail" so changed appropriately)

Getters created and return type hinted